### PR TITLE
Rewrite SheetLayout as Compose composable with AnchoredDraggable

### DIFF
--- a/CelestiaUI/src/main/java/space/celestia/celestiaui/resource/model/FeatureFlags.kt
+++ b/CelestiaUI/src/main/java/space/celestia/celestiaui/resource/model/FeatureFlags.kt
@@ -11,5 +11,6 @@ package space.celestia.celestiaui.resource.model
 
 data class FeatureFlags(
     val dummy: Boolean = false,
-    val composeSurface: Boolean = false
+    val composeSurface: Boolean = false,
+    val composeSheet: Boolean = false
 )

--- a/CelestiaUI/src/main/java/space/celestia/celestiaui/resource/model/FeatureFlagsManager.kt
+++ b/CelestiaUI/src/main/java/space/celestia/celestiaui/resource/model/FeatureFlagsManager.kt
@@ -22,7 +22,7 @@ class FeatureFlagsManager(
 ) {
     companion object {
         // Add new flag keys here
-        private val flagKeys = listOf("dummy", "composeSurface")
+        private val flagKeys = listOf("dummy", "composeSurface", "composeSheet")
     }
 
     suspend fun update(lang: String) {
@@ -58,7 +58,8 @@ class FeatureFlagsManager(
             val json = JSONObject(stored)
             FeatureFlags(
                 dummy = json.optBoolean("dummy", false),
-                composeSurface = json.optBoolean("composeSurface", false)
+                composeSurface = json.optBoolean("composeSurface", false),
+                composeSheet = json.optBoolean("composeSheet", false)
             )
         } catch (_: Throwable) {
             FeatureFlags()

--- a/app/src/main/java/space/celestia/mobilecelestia/MainActivity.kt
+++ b/app/src/main/java/space/celestia/mobilecelestia/MainActivity.kt
@@ -34,6 +34,7 @@ import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
 import androidx.appcompat.app.AppCompatDelegate
 import androidx.appcompat.widget.AppCompatImageButton
+import androidx.compose.runtime.Composable
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.platform.ViewCompositionStrategy
@@ -1863,7 +1864,7 @@ class MainActivity : AppCompatActivity(R.layout.activity_main),
 
     // Utilities
 
-    @androidx.compose.runtime.Composable
+    @Composable
     private fun ToolScreenContent() {
         ToolScreen(
             backStack = viewModel.backStack,

--- a/app/src/main/java/space/celestia/mobilecelestia/MainActivity.kt
+++ b/app/src/main/java/space/celestia/mobilecelestia/MainActivity.kt
@@ -111,6 +111,8 @@ import space.celestia.mobilecelestia.celestia.CelestiaPresentation
 import space.celestia.mobilecelestia.celestia.RendererSettings
 import space.celestia.mobilecelestia.common.EdgeInsets
 import space.celestia.mobilecelestia.common.RoundedCorners
+import space.celestia.mobilecelestia.common.LegacySheetLayout
+import space.celestia.mobilecelestia.common.SHEET_MAX_FULL_WIDTH_DP
 import space.celestia.mobilecelestia.common.SheetLayout
 import space.celestia.mobilecelestia.control.BottomControlAction
 import space.celestia.mobilecelestia.control.ContinuousAction
@@ -227,6 +229,9 @@ class MainActivity : AppCompatActivity(R.layout.activity_main),
 
     private val viewModel: MainViewModel by viewModels()
 
+    private val useComposeSheet: Boolean
+        get() = featureFlags.composeSheet
+
     private var mediaRouterCallback: MediaRouter.SimpleCallback? = null
 
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -293,37 +298,31 @@ class MainActivity : AppCompatActivity(R.layout.activity_main),
             }
         }
 
-        findViewById<ComposeView>(R.id.bottom_sheet_content).apply {
-            setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnDetachedFromWindow)
-            setContent {
-                Mdc3Theme {
-                    ToolScreen(
-                        backStack = viewModel.backStack,
-                        linkClicked = { link, localizable ->
-                            openLink(link, localizable)
-                        },
-                        providePreferredDisplay = {
-                            settingsProvidePreferredDisplay()
-                        },
-                        refreshRateChanged = {
-                            settingsRefreshRateChanged(it)
-                        },
-                        requestRunScript = {
-                            webRequestRunScript(it)
-                        },
-                        requestShareAddon = { name, id ->
-                            webRequestShareAddon(name, id)
-                        },
-                        shareRequested = {
-                            shareFavoriteItem(it)
-                        },
-                        openBookmarkRequested = {
-                            openFavoriteBookmark(it)
-                        },
-                        openScriptRequested = {
-                            openFavoriteScript(it)
+        if (useComposeSheet) {
+            findViewById<View>(R.id.bottom_sheet_insets).visibility = View.VISIBLE
+            findViewById<ComposeView>(R.id.bottom_sheet_host).apply {
+                setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnDetachedFromWindow)
+                setContent {
+                    Mdc3Theme {
+                        SheetLayout(
+                            visible = viewModel.bottomSheetVisible.value,
+                            onDismiss = {
+                                viewModel.bottomSheetVisible.value = false
+                                viewModel.backStack.clear()
+                            }
+                        ) {
+                            ToolScreenContent()
                         }
-                    )
+                    }
+                }
+            }
+        } else {
+            findViewById<ComposeView>(R.id.legacy_bottom_sheet_content).apply {
+                setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnDetachedFromWindow)
+                setContent {
+                    Mdc3Theme {
+                        ToolScreenContent()
+                    }
                 }
             }
         }
@@ -334,9 +333,11 @@ class MainActivity : AppCompatActivity(R.layout.activity_main),
             return@setOnApplyWindowInsetsListener insets
         }
 
-        findViewById<View>(R.id.close_button).setOnClickListener {
-            lifecycleScope.launch {
-                hideOverlay(true)
+        if (!useComposeSheet) {
+            findViewById<View>(R.id.close_button).setOnClickListener {
+                lifecycleScope.launch {
+                    hideOverlay(true)
+                }
             }
         }
 
@@ -368,14 +369,26 @@ class MainActivity : AppCompatActivity(R.layout.activity_main),
             return@setOnApplyWindowInsetsListener builder.build()
         }
 
-        val bottomSheetContainer = findViewById<View>(R.id.bottom_sheet)
-        ViewCompat.setOnApplyWindowInsetsListener(bottomSheetContainer) { _, insets ->
-            val systemBarInsets = insets.getInsetsIgnoringVisibility(WindowInsetsCompat.Type.systemBars())
-            val builder = WindowInsetsCompat.Builder(insets).setInsets(WindowInsetsCompat.Type.systemBars(), Insets.of(0, 0, 0, systemBarInsets.bottom))
-            return@setOnApplyWindowInsetsListener builder.build()
+        if (useComposeSheet) {
+            val bottomSheetContainer = findViewById<View>(R.id.bottom_sheet_insets)
+            ViewCompat.setOnApplyWindowInsetsListener(bottomSheetContainer) { _, insets ->
+                val systemBarInsets = insets.getInsetsIgnoringVisibility(WindowInsetsCompat.Type.systemBars())
+                WindowInsetsCompat.Builder(insets)
+                    .setInsets(WindowInsetsCompat.Type.systemBars(), Insets.of(0, 0, 0, systemBarInsets.bottom))
+                    .build()
+            }
+            bottomSheetContainer.systemUiVisibility = View.SYSTEM_UI_FLAG_LAYOUT_STABLE or View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN
+        } else {
+            val legacyBottomSheet = findViewById<View>(R.id.legacy_bottom_sheet)
+            ViewCompat.setOnApplyWindowInsetsListener(legacyBottomSheet) { _, insets ->
+                val systemBarInsets = insets.getInsetsIgnoringVisibility(WindowInsetsCompat.Type.systemBars())
+                WindowInsetsCompat.Builder(insets)
+                    .setInsets(WindowInsetsCompat.Type.systemBars(), Insets.of(0, 0, 0, systemBarInsets.bottom))
+                    .build()
+            }
+            legacyBottomSheet.systemUiVisibility = View.SYSTEM_UI_FLAG_LAYOUT_STABLE or View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN
         }
         findViewById<View>(R.id.drawer).systemUiVisibility = View.SYSTEM_UI_FLAG_LAYOUT_STABLE or View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN
-        bottomSheetContainer.systemUiVisibility = View.SYSTEM_UI_FLAG_LAYOUT_STABLE or View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN
         findViewById<View>(R.id.toolbar_overlay).systemUiVisibility = View.SYSTEM_UI_FLAG_LAYOUT_STABLE or View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN
 
         if (currentState == AppStatusReporter.State.LOADING_FAILURE || currentState == AppStatusReporter.State.EXTERNAL_LOADING_FAILURE) {
@@ -394,8 +407,10 @@ class MainActivity : AppCompatActivity(R.layout.activity_main),
 
             findViewById<View>(R.id.bottom_toolbar_container).visibility = if (toolbarVisible) View.VISIBLE else View.GONE
 
-            findViewById<View>(R.id.bottom_sheet_overlay).visibility = if (viewModel.bottomSheetVisible.value) View.VISIBLE else View.GONE
-            findViewById<View>(R.id.bottom_sheet_card).visibility = if (viewModel.bottomSheetVisible.value) View.VISIBLE else View.GONE
+            if (!useComposeSheet) {
+                findViewById<View>(R.id.legacy_bottom_sheet_overlay).visibility = if (viewModel.bottomSheetVisible.value) View.VISIBLE else View.GONE
+                findViewById<View>(R.id.legacy_bottom_sheet_card).visibility = if (viewModel.bottomSheetVisible.value) View.VISIBLE else View.GONE
+            }
 
             if (currentToolbarActions.isNotEmpty() && toolbarVisible) {
                 showToolbarActionsDirect(currentToolbarActions, currentToolbarOverflowActions)
@@ -597,7 +612,7 @@ class MainActivity : AppCompatActivity(R.layout.activity_main),
     private fun updateConfiguration(configuration: Configuration, windowInsets: WindowInsetsCompat?) {
         val isRTL = configuration.layoutDirection == LayoutDirection.RTL
 
-        val hasRegularHorizontalSpace =  configuration.screenWidthDp > SheetLayout.sheetMaxFullWidthDp
+        val hasRegularHorizontalSpace =  configuration.screenWidthDp > SHEET_MAX_FULL_WIDTH_DP
 
         val safeInsets = EdgeInsets(
             windowInsets,
@@ -610,10 +625,12 @@ class MainActivity : AppCompatActivity(R.layout.activity_main),
         val drawerParams = findViewById<View>(R.id.drawer).layoutParams
         drawerParams.width = resources.getDimensionPixelSize(R.dimen.toolbar_default_width) + safeInsetEnd
 
-        val bottomSheetContainer = findViewById<SheetLayout>(R.id.bottom_sheet_overlay)
-        bottomSheetContainer.edgeInsets = EdgeInsets(windowInsets?.systemWindowInsets)
-        bottomSheetContainer.useLandscapeLayout = hasRegularHorizontalSpace
-        bottomSheetContainer.requestLayout()
+        if (!useComposeSheet) {
+            val bottomSheetContainer = findViewById<LegacySheetLayout>(R.id.legacy_bottom_sheet_overlay)
+            bottomSheetContainer.edgeInsets = EdgeInsets(windowInsets?.systemWindowInsets)
+            bottomSheetContainer.useLandscapeLayout = hasRegularHorizontalSpace
+            bottomSheetContainer.requestLayout()
+        }
     }
 
     private fun loadExternalConfig() {
@@ -682,7 +699,9 @@ class MainActivity : AppCompatActivity(R.layout.activity_main),
 
     private fun celestiaLoadingFinished() {
         findViewById<View>(R.id.loading_fragment_container).visibility = View.GONE
-        findViewById<AppCompatImageButton>(R.id.close_button).contentDescription = CelestiaString("Close", "")
+        if (!useComposeSheet) {
+            findViewById<AppCompatImageButton>(R.id.close_button).contentDescription = CelestiaString("Close", "")
+        }
         showCelestiaPlus.value = purchaseManager.canUseInAppPurchase()
         findViewById<View>(R.id.drawer).visibility = View.VISIBLE
 
@@ -1425,7 +1444,8 @@ class MainActivity : AppCompatActivity(R.layout.activity_main),
         if (drawerLayout.isDrawerOpen(GravityCompat.END))
             return false
         // check bottom sheet
-        return findViewById<View>(R.id.bottom_sheet_overlay).visibility != View.VISIBLE
+        return if (useComposeSheet) !viewModel.bottomSheetVisible.value
+        else findViewById<View>(R.id.legacy_bottom_sheet_overlay).visibility != View.VISIBLE
     }
 
     override fun celestiaFragmentLoadingFromFallback() {
@@ -1478,10 +1498,15 @@ class MainActivity : AppCompatActivity(R.layout.activity_main),
         currentToolbarActions = listOf()
     }
 
-    private suspend fun hideBottomSheet(animated: Boolean) {
-        hideView(animated, R.id.bottom_sheet_card, false)
-        findViewById<View>(R.id.bottom_sheet_overlay).visibility = View.INVISIBLE
-        viewModel.bottomSheetVisible.value = false
+    private suspend fun hideBottomSheet(animated: Boolean = true) {
+        if (useComposeSheet) {
+            viewModel.bottomSheetVisible.value = false
+            viewModel.backStack.clear()
+        } else {
+            hideView(animated, R.id.legacy_bottom_sheet_card, false)
+            findViewById<View>(R.id.legacy_bottom_sheet_overlay).visibility = View.INVISIBLE
+            viewModel.bottomSheetVisible.value = false
+        }
     }
 
     private suspend fun showView(animated: Boolean, viewID: Int, horizontal: Boolean) {
@@ -1840,6 +1865,37 @@ class MainActivity : AppCompatActivity(R.layout.activity_main),
 
     // Utilities
 
+    @androidx.compose.runtime.Composable
+    private fun ToolScreenContent() {
+        ToolScreen(
+            backStack = viewModel.backStack,
+            linkClicked = { link, localizable ->
+                openLink(link, localizable)
+            },
+            providePreferredDisplay = {
+                settingsProvidePreferredDisplay()
+            },
+            refreshRateChanged = {
+                settingsRefreshRateChanged(it)
+            },
+            requestRunScript = {
+                webRequestRunScript(it)
+            },
+            requestShareAddon = { name, id ->
+                webRequestShareAddon(name, id)
+            },
+            shareRequested = {
+                shareFavoriteItem(it)
+            },
+            openBookmarkRequested = {
+                openFavoriteBookmark(it)
+            },
+            openScriptRequested = {
+                openFavoriteScript(it)
+            }
+        )
+    }
+
     private suspend fun showBottomSheetTool(page: ToolPage) {
         hideMenu(animated = true)
         showBottomSheetToolDirect(page)
@@ -1852,9 +1908,9 @@ class MainActivity : AppCompatActivity(R.layout.activity_main),
         }
         viewModel.backStack.add(page)
         viewModel.bottomSheetVisible.value = true
-        if (!wasVisible) {
-            findViewById<View>(R.id.bottom_sheet_overlay).visibility = View.VISIBLE
-            showView(true, R.id.bottom_sheet_card, false)
+        if (!useComposeSheet && !wasVisible) {
+            findViewById<View>(R.id.legacy_bottom_sheet_overlay).visibility = View.VISIBLE
+            showView(true, R.id.legacy_bottom_sheet_card, false)
         }
     }
 

--- a/app/src/main/java/space/celestia/mobilecelestia/MainActivity.kt
+++ b/app/src/main/java/space/celestia/mobilecelestia/MainActivity.kt
@@ -308,7 +308,6 @@ class MainActivity : AppCompatActivity(R.layout.activity_main),
                             visible = viewModel.bottomSheetVisible.value,
                             onDismiss = {
                                 viewModel.bottomSheetVisible.value = false
-                                viewModel.backStack.clear()
                             }
                         ) {
                             ToolScreenContent()
@@ -1501,7 +1500,6 @@ class MainActivity : AppCompatActivity(R.layout.activity_main),
     private suspend fun hideBottomSheet(animated: Boolean = true) {
         if (useComposeSheet) {
             viewModel.bottomSheetVisible.value = false
-            viewModel.backStack.clear()
         } else {
             hideView(animated, R.id.legacy_bottom_sheet_card, false)
             findViewById<View>(R.id.legacy_bottom_sheet_overlay).visibility = View.INVISIBLE

--- a/app/src/main/java/space/celestia/mobilecelestia/celestia/CelestiaFragment.kt
+++ b/app/src/main/java/space/celestia/mobilecelestia/celestia/CelestiaFragment.kt
@@ -55,7 +55,7 @@ import space.celestia.celestiaui.info.getAvailableMarkers
 import space.celestia.mobilecelestia.R
 import space.celestia.mobilecelestia.common.EdgeInsets
 import space.celestia.mobilecelestia.common.RoundedCorners
-import space.celestia.mobilecelestia.common.SheetLayout
+import space.celestia.mobilecelestia.common.SHEET_MAX_FULL_WIDTH_DP
 import space.celestia.celestiaui.info.model.CelestiaAction
 import space.celestia.celestiaui.info.model.perform
 import space.celestia.celestiaui.purchase.PurchaseManager
@@ -192,7 +192,7 @@ class CelestiaFragment: Fragment(), CelestiaControlView.Listener, CelestiaRender
         val weakSelf = WeakReference(this)
         ViewCompat.setOnApplyWindowInsetsListener(view) { _, insets ->
             val self = weakSelf.get() ?: return@setOnApplyWindowInsetsListener insets
-            val hasRegularHorizontalSpace =  self.resources.configuration.screenWidthDp > SheetLayout.sheetMaxFullWidthDp
+            val hasRegularHorizontalSpace =  self.resources.configuration.screenWidthDp > SHEET_MAX_FULL_WIDTH_DP
             val safeInsets = EdgeInsets(
                 insets,
                 if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) RoundedCorners(insets) else RoundedCorners(0, 0, 0, 0),

--- a/app/src/main/java/space/celestia/mobilecelestia/common/LegacySheetLayout.kt
+++ b/app/src/main/java/space/celestia/mobilecelestia/common/LegacySheetLayout.kt
@@ -1,0 +1,154 @@
+// LegacySheetLayout.kt
+//
+// Copyright (C) 2025, Celestia Development Team
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+
+package space.celestia.mobilecelestia.common
+
+import android.content.Context
+import android.util.AttributeSet
+import android.util.LayoutDirection
+import android.view.MotionEvent
+import android.view.View
+import android.view.ViewGroup
+import androidx.customview.widget.ViewDragHelper
+import kotlin.math.max
+import kotlin.math.min
+import androidx.core.view.isGone
+
+class LegacySheetLayout(context: Context, attrs: AttributeSet): ViewGroup(context, attrs) {
+    private val dragHelper: ViewDragHelper
+
+    private var capturedView: View? = null
+    private var capturedViewY: Int? = null
+
+    var edgeInsets: EdgeInsets = EdgeInsets()
+    var useLandscapeLayout = false
+
+    init {
+        val callback = object: ViewDragHelper.Callback() {
+            override fun tryCaptureView(child: View, pointerId: Int): Boolean {
+                return true
+            }
+
+            override fun onViewPositionChanged(
+                changedView: View,
+                left: Int,
+                top: Int,
+                dx: Int,
+                dy: Int
+            ) {
+                capturedView = changedView
+                capturedViewY = top
+            }
+
+            override fun clampViewPositionHorizontal(child: View, left: Int, dx: Int): Int {
+                return left - dx
+            }
+
+            override fun clampViewPositionVertical(child: View, top: Int, dy: Int): Int {
+                val maxHeight = ((height - edgeInsets.top - edgeInsets.bottom) * sheetMaxHeightRatio).toInt()
+                return min(max(top, max(height - maxHeight - edgeInsets.bottom, edgeInsets.top)), (height - sheetHandleHeight * resources.displayMetrics.density - edgeInsets.bottom).toInt())
+            }
+        }
+        dragHelper = ViewDragHelper.create(this, callback)
+    }
+
+    override fun onInterceptTouchEvent(ev: MotionEvent?): Boolean {
+        if (ev != null)
+            return dragHelper.shouldInterceptTouchEvent(ev)
+        return false
+    }
+
+    override fun onTouchEvent(event: MotionEvent?): Boolean {
+        if (event != null)
+            dragHelper.processTouchEvent(event)
+        return dragHelper.viewDragState != ViewDragHelper.STATE_IDLE
+    }
+
+    override fun onVisibilityChanged(changedView: View, visibility: Int) {
+        super.onVisibilityChanged(changedView, visibility)
+
+        if (visibility != VISIBLE) {
+            capturedView = null
+            capturedViewY = null
+        }
+    }
+
+    override fun onSizeChanged(w: Int, h: Int, oldw: Int, oldh: Int) {
+        super.onSizeChanged(w, h, oldw, oldh)
+
+        capturedView = null
+        capturedViewY = null
+    }
+
+    override fun onMeasure(widthMeasureSpec: Int, heightMeasureSpec: Int) {
+        val containerWidth = resolveSizeAndState(0, widthMeasureSpec, 0)
+        val containerHeight = resolveSizeAndState(0, heightMeasureSpec, 0)
+        val density = resources.displayMetrics.density
+        val shouldNotOccupyFullWidth = useLandscapeLayout
+
+        for (i in 0 until childCount) {
+            val child = getChildAt(i)
+
+            if (child.isGone)
+                continue
+
+            val childWidth = if (shouldNotOccupyFullWidth) calculateChildWidth(containerWidth, density) else (containerWidth - edgeInsets.left - edgeInsets.right)
+            val childHeight = min(containerHeight - edgeInsets.top, edgeInsets.bottom + ((containerHeight - edgeInsets.top - edgeInsets.bottom) * sheetMaxHeightRatio).toInt())
+            child.measure(MeasureSpec.makeMeasureSpec(childWidth, MeasureSpec.EXACTLY), MeasureSpec.makeMeasureSpec(childHeight, MeasureSpec.EXACTLY))
+        }
+        setMeasuredDimension(containerWidth, containerHeight)
+    }
+
+    override fun onLayout(changed: Boolean, left: Int, top: Int, right: Int, bottom: Int) {
+        val isRTL = resources.configuration.layoutDirection == LayoutDirection.RTL
+        val density = resources.displayMetrics.density
+
+        val containerWidth = right - left
+        val containerHeight = bottom - top
+
+        val shouldNotOccupyFullWidth = useLandscapeLayout
+
+        for (i in 0 until childCount) {
+            val child = getChildAt(i)
+            if (child.isGone)
+                continue
+
+            val sheetHeight = min(containerHeight - edgeInsets.top, edgeInsets.bottom + ((containerHeight - edgeInsets.top - edgeInsets.bottom) * sheetMaxHeightRatio).toInt())
+
+            var y = containerHeight - sheetHeight
+            if (child == capturedView) {
+                val preservedY = capturedViewY
+                if (preservedY != null) {
+                    y = preservedY
+                }
+            }
+
+            if (!shouldNotOccupyFullWidth) {
+                child.layout(edgeInsets.left, y, containerWidth - edgeInsets.right, y + sheetHeight)
+            } else {
+                val width = calculateChildWidth(containerWidth, density)
+                if (isRTL) {
+                    child.layout((containerWidth - edgeInsets.right - width - sheetPaddingNonFullWidthDp * density).toInt(), y, (containerWidth - edgeInsets.right - sheetPaddingNonFullWidthDp * density).toInt(), y + sheetHeight)
+                } else {
+                    child.layout((sheetPaddingNonFullWidthDp * density + edgeInsets.left).toInt(), y, (width + sheetPaddingNonFullWidthDp * density + edgeInsets.left).toInt(), y + sheetHeight)
+                }
+            }
+        }
+    }
+
+    private fun calculateChildWidth(containerWidth: Int, density: Float): Int {
+        return (density * (if (containerWidth / density > 1024) 393 else 320)).toInt()
+    }
+
+    companion object {
+        private const val sheetPaddingNonFullWidthDp = 16
+        private const val sheetMaxHeightRatio = 0.9
+        private const val sheetHandleHeight = 30
+    }
+}

--- a/app/src/main/java/space/celestia/mobilecelestia/common/SheetLayout.kt
+++ b/app/src/main/java/space/celestia/mobilecelestia/common/SheetLayout.kt
@@ -9,147 +9,220 @@
 
 package space.celestia.mobilecelestia.common
 
-import android.content.Context
-import android.util.AttributeSet
-import android.util.LayoutDirection
-import android.view.MotionEvent
-import android.view.View
-import android.view.ViewGroup
-import androidx.customview.widget.ViewDragHelper
-import kotlin.math.max
-import kotlin.math.min
-import androidx.core.view.isGone
+import androidx.compose.foundation.background
+import androidx.compose.foundation.gestures.AnchoredDraggableState
+import androidx.compose.foundation.gestures.DraggableAnchors
+import androidx.compose.foundation.gestures.Orientation
+import androidx.compose.foundation.gestures.anchoredDraggable
+import androidx.compose.foundation.gestures.animateTo
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxWithConstraints
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.displayCutout
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.safeDrawing
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.offset
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.SideEffect
+import androidx.compose.runtime.derivedStateOf
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberUpdatedState
+import androidx.compose.runtime.snapshotFlow
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.input.nestedscroll.NestedScrollConnection
+import androidx.compose.ui.input.nestedscroll.NestedScrollSource
+import androidx.compose.ui.input.nestedscroll.nestedScroll
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.platform.LocalLayoutDirection
+import androidx.compose.ui.platform.LocalWindowInfo
+import androidx.compose.ui.unit.IntOffset
+import androidx.compose.ui.unit.LayoutDirection
+import androidx.compose.ui.unit.Velocity
+import androidx.compose.ui.unit.dp
+import kotlin.math.roundToInt
 
-class SheetLayout(context: Context, attrs: AttributeSet): ViewGroup(context, attrs) {
-    private val dragHelper: ViewDragHelper
+enum class SheetDetent { Hidden, PartiallyExpanded, Expanded }
 
-    private var capturedView: View? = null
-    private var capturedViewY: Int? = null
+@Composable
+fun SheetLayout(
+    visible: Boolean,
+    onDismiss: () -> Unit,
+    modifier: Modifier = Modifier,
+    content: @Composable () -> Unit,
+) {
+    val density = LocalDensity.current
+    val layoutDirection = LocalLayoutDirection.current
+    val containerSize = LocalWindowInfo.current.containerSize
+    BoxWithConstraints(modifier = modifier.fillMaxSize()) {
+        val fullHeightPx = constraints.maxHeight.toFloat()
+        val isWideScreen = with(density) { containerSize.width.toDp() } > SHEET_MAX_FULL_WIDTH_DP.dp
 
-    var edgeInsets: EdgeInsets = EdgeInsets()
-    var useLandscapeLayout = false
+        val cutoutTop = with(density) { WindowInsets.displayCutout.getTop(this).toFloat() }
+        val cutoutBottom = with(density) { WindowInsets.displayCutout.getBottom(this).toFloat() }
+        val safeHeightPx = fullHeightPx - cutoutTop - cutoutBottom
+        val sheetHeightPx = cutoutBottom + safeHeightPx * SHEET_MAX_HEIGHT_RATIO
 
-    init {
-        val callback = object: ViewDragHelper.Callback() {
-            override fun tryCaptureView(child: View, pointerId: Int): Boolean {
-                return true
-            }
+        val expandedOffsetPx = fullHeightPx - sheetHeightPx
+        val partialOffsetPx = fullHeightPx * 0.5f
+        val hiddenOffsetPx = fullHeightPx
 
-            override fun onViewPositionChanged(
-                changedView: View,
-                left: Int,
-                top: Int,
-                dx: Int,
-                dy: Int
-            ) {
-                capturedView = changedView
-                capturedViewY = top
-            }
+        val state = remember {
+            AnchoredDraggableState(initialValue = if (visible) SheetDetent.Expanded else SheetDetent.Hidden)
+        }
 
-            override fun clampViewPositionHorizontal(child: View, left: Int, dx: Int): Int {
-                return left - dx
-            }
-
-            override fun clampViewPositionVertical(child: View, top: Int, dy: Int): Int {
-                val maxHeight = ((height - edgeInsets.top - edgeInsets.bottom) * sheetMaxHeightRatio).toInt()
-                return min(max(top, max(height - maxHeight - edgeInsets.bottom, edgeInsets.top)), (height - sheetHandleHeight * resources.displayMetrics.density - edgeInsets.bottom).toInt())
+        SideEffect {
+            if (fullHeightPx > 0) {
+                state.updateAnchors(
+                    newAnchors = DraggableAnchors {
+                        SheetDetent.Hidden at hiddenOffsetPx
+                        SheetDetent.PartiallyExpanded at partialOffsetPx
+                        SheetDetent.Expanded at expandedOffsetPx
+                    },
+                    newTarget = if (visible) state.currentValue else SheetDetent.Hidden
+                )
             }
         }
-        dragHelper = ViewDragHelper.create(this, callback)
-    }
 
-    override fun onInterceptTouchEvent(ev: MotionEvent?): Boolean {
-        if (ev != null)
-            return dragHelper.shouldInterceptTouchEvent(ev)
-        return false
-    }
-
-    override fun onTouchEvent(event: MotionEvent?): Boolean {
-        if (event != null)
-            dragHelper.processTouchEvent(event)
-        return dragHelper.viewDragState != ViewDragHelper.STATE_IDLE
-    }
-
-    override fun onVisibilityChanged(changedView: View, visibility: Int) {
-        super.onVisibilityChanged(changedView, visibility)
-
-        if (visibility != VISIBLE) {
-            capturedView = null
-            capturedViewY = null
+        LaunchedEffect(visible) {
+            state.animateTo(if (visible) SheetDetent.Expanded else SheetDetent.Hidden)
         }
-    }
 
-    override fun onSizeChanged(w: Int, h: Int, oldw: Int, oldh: Int) {
-        super.onSizeChanged(w, h, oldw, oldh)
-
-        capturedView = null
-        capturedViewY = null
-    }
-
-    override fun onMeasure(widthMeasureSpec: Int, heightMeasureSpec: Int) {
-        val containerWidth = resolveSizeAndState(0, widthMeasureSpec, 0)
-        val containerHeight = resolveSizeAndState(0, heightMeasureSpec, 0)
-        val density = resources.displayMetrics.density
-        val shouldNotOccupyFullWidth = useLandscapeLayout
-
-        for (i in 0 until childCount) {
-            val child = getChildAt(i)
-
-            if (child.isGone)
-                continue
-
-            val childWidth = if (shouldNotOccupyFullWidth) calculateChildWidth(containerWidth, density) else (containerWidth - edgeInsets.left - edgeInsets.right)
-            val childHeight = min(containerHeight - edgeInsets.top, edgeInsets.bottom + ((containerHeight - edgeInsets.top - edgeInsets.bottom) * sheetMaxHeightRatio).toInt())
-            child.measure(MeasureSpec.makeMeasureSpec(childWidth, MeasureSpec.EXACTLY), MeasureSpec.makeMeasureSpec(childHeight, MeasureSpec.EXACTLY))
-        }
-        setMeasuredDimension(containerWidth, containerHeight)
-    }
-
-    override fun onLayout(changed: Boolean, left: Int, top: Int, right: Int, bottom: Int) {
-        val isRTL = resources.configuration.layoutDirection == LayoutDirection.RTL
-        val density = resources.displayMetrics.density
-
-        val containerWidth = right - left
-        val containerHeight = bottom - top
-
-        val shouldNotOccupyFullWidth = useLandscapeLayout
-
-        for (i in 0 until childCount) {
-            val child = getChildAt(i)
-            if (child.isGone)
-                continue
-
-            val sheetHeight = min(containerHeight - edgeInsets.top, edgeInsets.bottom + ((containerHeight - edgeInsets.top - edgeInsets.bottom) * sheetMaxHeightRatio).toInt())
-
-            var y = containerHeight - sheetHeight
-            if (child == capturedView) {
-                val preservedY = capturedViewY
-                if (preservedY != null) {
-                    y = preservedY
+        val currentOnDismiss by rememberUpdatedState(onDismiss)
+        LaunchedEffect(Unit) {
+            var previousValue = state.currentValue
+            snapshotFlow { state.currentValue }
+                .collect { value ->
+                    if (value == SheetDetent.Hidden && previousValue != SheetDetent.Hidden) {
+                        currentOnDismiss()
+                    }
+                    previousValue = value
                 }
-            }
+        }
 
-            if (!shouldNotOccupyFullWidth) {
-                child.layout(edgeInsets.left, y, containerWidth - edgeInsets.right, y + sheetHeight)
+        val nestedScrollConnection = remember(state) {
+            SheetNestedScrollConnection(state)
+        }
+
+        val sheetOffset by remember {
+            derivedStateOf { state.offset }
+        }
+        val isSheetVisible = !sheetOffset.isNaN() && sheetOffset < fullHeightPx
+
+        if (isSheetVisible) {
+            // Sheet
+            val sheetAlignment = if (isWideScreen) {
+                if (layoutDirection == LayoutDirection.Rtl) Alignment.BottomEnd else Alignment.BottomStart
             } else {
-                val width = calculateChildWidth(containerWidth, density)
-                if (isRTL) {
-                    child.layout((containerWidth - edgeInsets.right - width - sheetPaddingNonFullWidthDp * density).toInt(), y, (containerWidth - edgeInsets.right - sheetPaddingNonFullWidthDp * density).toInt(), y + sheetHeight)
-                } else {
-                    child.layout((sheetPaddingNonFullWidthDp * density + edgeInsets.left).toInt(), y, (width + sheetPaddingNonFullWidthDp * density + edgeInsets.left).toInt(), y + sheetHeight)
+                Alignment.BottomCenter
+            }
+
+            val safeStart = with(density) {
+                val insets = WindowInsets.safeDrawing
+                if (layoutDirection == LayoutDirection.Rtl) insets.getRight(this, layoutDirection).toDp()
+                else insets.getLeft(this, layoutDirection).toDp()
+            }
+
+            val sheetWidthModifier = if (isWideScreen) {
+                val containerWidthDp = with(density) { containerSize.width.toDp() }
+                val widthDp = if (containerWidthDp > SHEET_WIDE_THRESHOLD_DP.dp) SHEET_WIDE_WIDTH_DP.dp else SHEET_NARROW_WIDTH_DP.dp
+                Modifier.padding(start = safeStart + SHEET_LANDSCAPE_PADDING_DP.dp).width(widthDp)
+            } else {
+                Modifier.fillMaxWidth()
+            }
+
+            val yOffset = (sheetOffset - expandedOffsetPx).roundToInt().coerceAtLeast(0)
+
+            Surface(
+                modifier = Modifier
+                    .align(sheetAlignment)
+                    .then(sheetWidthModifier)
+                    .height(with(density) { sheetHeightPx.toDp() })
+                    .offset { IntOffset(0, yOffset) },
+                shape = RoundedCornerShape(topStart = 24.dp, topEnd = 24.dp),
+                color = MaterialTheme.colorScheme.surfaceContainerLow,
+                shadowElevation = 1.dp,
+            ) {
+                Column(modifier = Modifier.fillMaxSize()) {
+                    // Drag handle
+                    Box(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .height(32.dp)
+                            .anchoredDraggable(state, Orientation.Vertical),
+                        contentAlignment = Alignment.Center
+                    ) {
+                        Box(
+                            modifier = Modifier
+                                .width(32.dp)
+                                .height(4.dp)
+                                .background(
+                                    MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.4f),
+                                    RoundedCornerShape(2.dp)
+                                )
+                        )
+                    }
+                    Box(modifier = Modifier.weight(1f).nestedScroll(nestedScrollConnection)) {
+                        content()
+                    }
                 }
             }
         }
-    }
-
-    private fun calculateChildWidth(containerWidth: Int, density: Float): Int {
-        return (density * (if (containerWidth / density > 1024) 393 else 320)).toInt()
-    }
-
-    companion object {
-        private const val sheetPaddingNonFullWidthDp = 16
-        private const val sheetMaxHeightRatio = 0.9
-        private const val sheetHandleHeight = 30
-        const val sheetMaxFullWidthDp = 600
     }
 }
+
+private class SheetNestedScrollConnection(
+    private val state: AnchoredDraggableState<SheetDetent>
+) : NestedScrollConnection {
+
+    override fun onPreScroll(available: Offset, source: NestedScrollSource): Offset {
+        val delta = available.y
+        return if (delta < 0 && source == NestedScrollSource.UserInput) {
+            Offset(0f, state.dispatchRawDelta(delta))
+        } else {
+            Offset.Zero
+        }
+    }
+
+    override fun onPostScroll(consumed: Offset, available: Offset, source: NestedScrollSource): Offset {
+        return if (source == NestedScrollSource.UserInput) {
+            Offset(0f, state.dispatchRawDelta(available.y))
+        } else {
+            Offset.Zero
+        }
+    }
+
+    override suspend fun onPreFling(available: Velocity): Velocity {
+        val toFling = available.y
+        return if (toFling < 0 && state.requireOffset() > state.anchors.minPosition()) {
+            state.animateTo(state.targetValue)
+            available
+        } else {
+            Velocity.Zero
+        }
+    }
+
+    override suspend fun onPostFling(consumed: Velocity, available: Velocity): Velocity {
+        state.animateTo(state.targetValue)
+        return available
+    }
+}
+
+const val SHEET_MAX_FULL_WIDTH_DP = 600
+
+private const val SHEET_MAX_HEIGHT_RATIO = 0.9f
+private const val SHEET_LANDSCAPE_PADDING_DP = 16
+private const val SHEET_WIDE_THRESHOLD_DP = 1024
+private const val SHEET_WIDE_WIDTH_DP = 393
+private const val SHEET_NARROW_WIDTH_DP = 320

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -57,15 +57,15 @@
             </com.google.android.material.floatingtoolbar.FloatingToolbarLayout>
         </FrameLayout>
 
-        <space.celestia.mobilecelestia.common.SheetLayout
-            android:id="@+id/bottom_sheet_overlay"
+        <space.celestia.mobilecelestia.common.LegacySheetLayout
+            android:id="@+id/legacy_bottom_sheet_overlay"
             android:layout_width="match_parent"
             android:layout_height="match_parent"
-            android:visibility="invisible"
+            android:visibility="gone"
             style="@style/Container">
 
             <FrameLayout
-                android:id="@+id/bottom_sheet_card"
+                android:id="@+id/legacy_bottom_sheet_card"
                 android:layout_width="0dp"
                 android:layout_height="0dp"
                 android:background="@drawable/bottom_sheet_card_background">
@@ -95,20 +95,31 @@
                             android:background="@drawable/grabber"/>
                     </FrameLayout>
                     <FrameLayout
-                        android:id="@+id/bottom_sheet"
+                        android:id="@+id/legacy_bottom_sheet"
                         android:layout_width="match_parent"
                         android:layout_height="0dp"
                         android:layout_weight="1"
                         android:clickable="true">
                         <androidx.compose.ui.platform.ComposeView
-                            android:id="@+id/bottom_sheet_content"
+                            android:id="@+id/legacy_bottom_sheet_content"
                             android:layout_width="match_parent"
                             android:layout_height="match_parent"/>
                     </FrameLayout>
                 </LinearLayout>
             </FrameLayout>
 
-        </space.celestia.mobilecelestia.common.SheetLayout>
+        </space.celestia.mobilecelestia.common.LegacySheetLayout>
+
+        <FrameLayout
+            android:id="@+id/bottom_sheet_insets"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:visibility="gone">
+            <androidx.compose.ui.platform.ComposeView
+                android:id="@+id/bottom_sheet_host"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent" />
+        </FrameLayout>
 
         <androidx.compose.ui.platform.ComposeView
             android:id="@+id/loading_fragment_container"


### PR DESCRIPTION
Replace the View-based SheetLayout (ViewDragHelper) with a Compose composable that supports:
- AnchoredDraggable with three detents (hidden, partial, expanded)
- NestedScrollConnection for scroll-to-expand/collapse with Compose scrollable content, while preserving normal scroll for View content (WebView)
- Leading alignment in landscape with width logic matching the old SheetLayout (320dp/393dp based on screen width)
- Display cutout-aware sheet height (0.9 of safe area + bottom inset)
- Edge-to-edge support via FrameLayout insets wrapper that passes bottom system bar insets to Compose using getInsetsIgnoringVisibility
- Drag handle on the sheet header for direct drag

Simplify MainActivity bottom sheet management to pure state toggles, removing ObjectAnimator show/hide and manual view visibility handling.